### PR TITLE
(fix): Fixed GA release step - upgrade pnpm/action-setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: pnpm/action-setup@v2.4.0
+      - uses: pnpm/action-setup@v4
         with:
           version: 8.6.11
 


### PR DESCRIPTION
- Upgraded `pnpm/action-setup` to `v4` due to failing release step.

This was done as a recommended step to fix an issue reported [here](https://github.com/pnpm/action-setup/issues/135#issuecomment-2206861174)